### PR TITLE
Added a quick bootstrap script to the package.json file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cd goll-e
 # Run the bootstrapper script.
 # This will globally install gulp, jison and bower.
 npm run bootstrap
+npm install
 
 # Run the test suite.
 gulp ci
@@ -39,6 +40,7 @@ gulp ci
 # Install dependencies for the example implementation.
 cd examples
 npm install && bower install
+npm start
 ````
 
 Navigate to localhost:3000 in Chrome, and voila.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,21 @@ bower install goll-e
 Development Environment:
 
 ````
+# Clone the repo.
 git clone https://github.com/twosigma/goll-e.git
 cd goll-e
-npm install
-bower install
+
+# Run the bootstrapper script.
+# This will globally install gulp, jison and bower.
+npm run bootstrap
+
+# Run the test suite.
 gulp ci
+
+# Install dependencies for the example implementation.
+cd examples
+npm install && bower install
 ````
+
+Navigate to localhost:3000 in Chrome, and voila.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "test": "gulp ci"
+    "test": "gulp ci",
+    "bootstrap": "npm install -g bower gulp jison"
   },
   "devDependencies": {
     "browserify": "^6.1.0",


### PR DESCRIPTION
To quickly bootstrap a development environment, run `npm run bootstrap`.
This will install bower, jison and gulp globally for you.
